### PR TITLE
Move repolinter to philips-forks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ LABEL maintainer="Brend Smits <brend.smits@philips.com>"
 WORKDIR /app
 COPY . /app
 
-RUN git clone --depth=1 https://github.com/philips-labs/repolinter.git && cd repolinter && npm i --production && cd ..
+RUN git clone --depth=1 https://github.com/philips-forks/repolinter.git && cd repolinter && npm i --production && cd ..
 
 ENTRYPOINT ["/app/bin/loop.sh"]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After stumbling upon Repolinter and Newrelics Action, we decided we wanted somet
 
 ### Built With
 
-- [Repolinter](https://github.com/philips-labs/repolinter) (forked, [original here](https://github.com/todogroup/repolinter))
+- [Repolinter](https://github.com/philips-forks/repolinter) (forked, [original here](https://github.com/todogroup/repolinter))
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 


### PR DESCRIPTION
We've moved repolinter from philips-labs to philips-forks.

We need to adjust this action accordingly.